### PR TITLE
Fixed the fatal log to load .env only in the local environment

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -24,10 +24,12 @@ type Dependency struct {
 var db *gorm.DB
 
 func initDB() {
-	// Load environment variables
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
+	// Only load .env in local environment
+	if _, exists := os.LookupEnv("RENDER"); !exists {
+		err := godotenv.Load()
+		if err != nil {
+			log.Println("⚠️ Warning: No .env file found, using system environment variables.")
+		}
 	}
 
 	// Database connection string


### PR DESCRIPTION
# Pull Request Overview

**Description:**

The code was giving fatal warning when .env was not present even in the production environment which should not be there and was correct. This PR fixes that issue to load the .env file only in the local environment.

Closes #NULL

## PR Classification (Select all that apply)

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [ ] 🔄 Refactor
- [ ] ⚡ Optimization
- [ ] 🎨 Styles/Design
- [ ] 🧪 Test Cases
- [ ] 📝 Documentation Update

## Related Articles & Documentation

- Related Article: [NULL]
- Related Documentation: [NULL]

## Nature of the Change

Indicate the type of change being introduced in this PR:

- [x] 🐞 Bug fix (fixes a non-breaking issue)
- [ ] ✨ New feature (adds non-breaking functionality)
- [ ] 💥 Breaking change (alters existing functionality in a non-backward-compatible way)
- [ ] 📝 Documentation update (requires changes to existing documentation)

# Testing & Verification

Has this change been tested?

- [x] Yes
- [ ] No

Please detail the tests conducted to validate the changes. Include steps to reproduce, and any relevant information about test environments or configurations.

# Media Reference (Image/Video):

Attach any relevant images or videos to demonstrate the resolved bug or newly introduced feature.

---

_Ensure your code adheres to project standards and includes proper comments or documentation where applicable._
